### PR TITLE
Fix/py2to3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     download_url='https://github.com/danthedeckie/simpleeval/tarball/' + version,
     keywords=['eval', 'simple', 'expression', 'parse', 'ast'],
     test_suite='test_simpleeval',
-    use_2to3=True,
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '0.10.0'
+__version__ = '0.11.0'
 
 setup(
     name='simpleeval',

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,18 @@
-import subprocess
 from setuptools import setup
 
-
-def get_version():
-    """Load version"""
-    with open("VERSION") as buffer:
-            return buffer.readline().strip()
-
-version = get_version()
+__version__ = '0.10.0'
 
 setup(
     name='simpleeval',
     py_modules=['simpleeval'],
-    version=version,
+    version=__version__,
     description='A simple, safe single expression evaluator library.',
     long_description=open('README.rst', 'r').read(),
     long_description_content_type='text/x-rst',
     author='Daniel Fairhead',
     author_email='danthedeckie@gmail.com',
     url='https://github.com/danthedeckie/simpleeval',
-    download_url='https://github.com/danthedeckie/simpleeval/tarball/' + version,
+    download_url='https://github.com/danthedeckie/simpleeval/tarball/' + __version__,
     keywords=['eval', 'simple', 'expression', 'parse', 'ast'],
     test_suite='test_simpleeval',
     classifiers=['Development Status :: 4 - Beta',


### PR DESCRIPTION
This MR does two things: 
* remove 2to3
* harcode version in setup.py to ensure it can be installed with  `pip install git+https://smart-robotics/simpleeval@fix/py2to3`